### PR TITLE
Persist and respect ignore_ssl for Unraid TLS verification with compatibility shim and improved logging

### DIFF
--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -31,6 +31,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     DEFAULT_PORT,
     DOMAIN,
     REPAIR_AUTH_FAILED,
@@ -118,9 +119,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     api_key = entry.data[CONF_API_KEY]
     use_ssl = entry.data.get(CONF_SSL, True)
 
+    ignore_ssl = entry.data.get(CONF_IGNORE_SSL)
+    if ignore_ssl is None:
+        # Compatibility shim for entries created while CONF_SSL incorrectly
+        # represented certificate verification state. Those entries stored
+        # CONF_SSL=False after self-signed fallback, while transport remained HTTPS.
+        if use_ssl is False:
+            ignore_ssl = True
+            use_ssl = True
+            _LOGGER.debug(
+                "Applying SSL compatibility fallback for %s:%s (missing %s, treating legacy ssl=false as ignore_ssl=true)",
+                host,
+                port,
+                CONF_IGNORE_SSL,
+            )
+            hass.config_entries.async_update_entry(
+                entry,
+                data={
+                    **entry.data,
+                    CONF_SSL: use_ssl,
+                    CONF_IGNORE_SSL: ignore_ssl,
+                },
+            )
+        else:
+            ignore_ssl = False
+
+    verify_ssl = not ignore_ssl
+
+    _LOGGER.debug(
+        "Starting Unraid setup for %s:%s ssl=%s ignore_ssl=%s",
+        host,
+        port,
+        use_ssl,
+        ignore_ssl,
+    )
+
     # Get HA's aiohttp session for proper connection pooling
-    # Use verify_ssl based on whether SSL connection was established
-    session = async_get_clientsession(hass, verify_ssl=use_ssl)
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
 
     # Create API client with injected session (using unraid_api library >=1.5.0).
     # The library handles SSL detection automatically via HTTP probe.
@@ -128,7 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         host=host,
         http_port=port,
         api_key=api_key,
-        verify_ssl=use_ssl,
+        verify_ssl=verify_ssl,
         session=session,
     )
 
@@ -136,9 +171,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
     try:
         await api_client.test_connection()
         info = await api_client.get_server_info()
+        _LOGGER.debug(
+            "Initial connectivity succeeded for %s:%s with TLS verification %s",
+            host,
+            port,
+            "enabled" if verify_ssl else "disabled",
+        )
         # Clear any previous auth repair issues on successful connection
         ir.async_delete_issue(hass, DOMAIN, REPAIR_AUTH_FAILED)
     except UnraidAuthenticationError as err:
+        _LOGGER.warning("Authentication failed for %s:%s: %s", host, port, err)
         await api_client.close()
         # Create repair issue for auth failure
         ir.async_create_issue(
@@ -154,14 +196,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnraidConfigEntry) -> bo
         msg = f"Authentication failed for Unraid server {host}"
         raise ConfigEntryAuthFailed(msg) from err
     except UnraidSSLError as err:
+        _LOGGER.warning("TLS verification failed for %s:%s: %s", host, port, err)
         await api_client.close()
         msg = f"SSL certificate error connecting to Unraid server {host}: {err}"
         raise ConfigEntryNotReady(msg) from err
     except (UnraidConnectionError, UnraidTimeoutError) as err:
+        _LOGGER.warning("Connection failure for %s:%s: %s", host, port, err)
         await api_client.close()
         msg = f"Failed to connect to Unraid server: {err}"
         raise ConfigEntryNotReady(msg) from err
     except UnraidAPIError as err:
+        _LOGGER.warning("Unraid API error for %s:%s: %s", host, port, err)
         await api_client.close()
         msg = f"Unraid API error connecting to server {host}: {err}"
         raise ConfigEntryNotReady(msg) from err

--- a/custom_components/unraid/config_flow.py
+++ b/custom_components/unraid/config_flow.py
@@ -23,6 +23,7 @@ from unraid_api.exceptions import (
 )
 
 from .const import (
+    CONF_IGNORE_SSL,
     CONF_UPS_CAPACITY_VA,
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_PORT,
@@ -52,7 +53,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._server_uuid: str | None = None
         self._server_hostname: str | None = None
-        self._use_ssl: bool = True  # Track whether SSL connection succeeded
+        self._use_ssl: bool = True
+        self._ignore_ssl: bool = False
 
     @staticmethod
     def async_get_options_flow(
@@ -112,11 +114,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 title = self._server_hostname or user_input[CONF_HOST]
 
                 _LOGGER.info(
-                    "Creating config entry for %s (UUID: %s) port=%s ssl=%s",
+                    "Creating config entry for %s (UUID: %s) port=%s ssl=%s ignore_ssl=%s",
                     title,
                     unique_id,
                     user_input.get(CONF_PORT, DEFAULT_PORT),
                     self._use_ssl,
+                    self._ignore_ssl,
                 )
                 return self.async_create_entry(
                     title=title,
@@ -125,6 +128,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
                         CONF_API_KEY: user_input[CONF_API_KEY],
                         CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
                     },
                     options={
                         CONF_UPS_CAPACITY_VA: DEFAULT_UPS_CAPACITY_VA,
@@ -186,8 +190,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         api_key = user_input[CONF_API_KEY].strip()
         port = user_input.get(CONF_PORT, DEFAULT_PORT)
 
-        # Reset SSL state to default
+        # Reset SSL state to defaults for each test
         self._use_ssl = True
+        self._ignore_ssl = False
+
+        _LOGGER.debug(
+            "Starting connectivity test for %s:%s ssl=%s ignore_ssl=%s",
+            host,
+            port,
+            self._use_ssl,
+            self._ignore_ssl,
+        )
 
         session = async_get_clientsession(self.hass, verify_ssl=True)
 
@@ -203,10 +216,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             await self._validate_connection(api_client, host)
+            _LOGGER.info(
+                "Initial connectivity test succeeded for %s:%s with TLS verification enabled",
+                host,
+                port,
+            )
         except SSLCertificateError as err:
             _LOGGER.debug(
-                "SSL verification failed for %s, retrying with verify_ssl=False: %s",
+                "TLS certificate verification failed for %s:%s, retrying with verification disabled: %s",
                 host,
+                port,
                 err,
             )
             await api_client.close()
@@ -220,14 +239,22 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 await self._validate_connection(fallback_client, host)
-                # Success with SSL verification disabled
-                self._use_ssl = False
+                # Keep SSL transport enabled, disable verification for this host.
+                self._use_ssl = True
+                self._ignore_ssl = True
                 _LOGGER.info(
-                    "Connected to %s with self-signed cert (SSL verify disabled)",
+                    "Connected to %s:%s with TLS verification disabled due to self-signed certificate",
                     host,
+                    port,
                 )
             except CannotConnectError as fallback_err:
                 # Keep original failure reason if fallback also fails
+                _LOGGER.debug(
+                    "Fallback connection attempt failed for %s:%s after TLS verification error: %s",
+                    host,
+                    port,
+                    fallback_err,
+                )
                 raise err from fallback_err
             finally:
                 await fallback_client.close()
@@ -351,7 +378,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={**user_input, CONF_SSL: self._use_ssl},
+                    data_updates={
+                        **user_input,
+                        CONF_SSL: self._use_ssl,
+                        CONF_IGNORE_SSL: self._ignore_ssl,
+                    },
                     reason="reauth_successful",
                 )
 
@@ -390,7 +421,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                     return self.async_update_reload_and_abort(
                         reconfigure_entry,
-                        data_updates={**user_input, CONF_SSL: self._use_ssl},
+                        data_updates={
+                            **user_input,
+                            CONF_SSL: self._use_ssl,
+                            CONF_IGNORE_SSL: self._ignore_ssl,
+                        },
                     )
 
                 except InvalidAuthError:

--- a/custom_components/unraid/const.py
+++ b/custom_components/unraid/const.py
@@ -63,6 +63,7 @@ PLACEHOLDER_UUIDS: Final = frozenset(
 # =============================================================================
 # Configuration Keys
 # =============================================================================
+CONF_IGNORE_SSL: Final = "ignore_ssl"
 CONF_UPS_CAPACITY_VA: Final = "ups_capacity_va"
 CONF_UPS_NOMINAL_POWER: Final = "ups_nominal_power"
 


### PR DESCRIPTION
### Motivation
- Provide explicit persistence of TLS certificate verification state for Unraid when users accept self-signed certificates. 
- Avoid treating `CONF_SSL` as both transport mode and verification flag by introducing a separate `CONF_IGNORE_SSL` setting. 
- Maintain compatibility with existing config entries created by earlier flows that used `CONF_SSL=False` to indicate verification should be ignored.

### Description
- Add `CONF_IGNORE_SSL` to `const.py` and surface it through the config flow by tracking `self._ignore_ssl` and storing `CONF_IGNORE_SSL` when creating or updating entries. 
- Update `config_flow.py` to retry once with `verify_ssl=False` on TLS verification failures and set `self._ignore_ssl = True` when the fallback succeeds, while keeping the transport as HTTPS (`self._use_ssl = True`). 
- In `__init__.py` read `CONF_IGNORE_SSL`, apply a compatibility shim that converts legacy entries where `CONF_SSL=False` into `CONF_SSL=True` with `CONF_IGNORE_SSL=True`, update the entry data, and compute `verify_ssl = not ignore_ssl`. 
- Pass `verify_ssl` to `async_get_clientsession` and `UnraidClient`, add debug/info/warning logs for connection attempts and failures, and improve exception logging for authentication, TLS, connection, and API errors. 
- Preserve existing behavior for server info and coordinators while ensuring proper TLS verification handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3cf46760832ba4d8bb666107587b)